### PR TITLE
Support probability checks

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -8,7 +8,9 @@
       "elm/core": "1.0.5",
       "elm/html": "1.0.0",
       "elm/json": "1.1.3",
-      "elm/time": "1.0.0"
+      "elm/random": "1.0.0",
+      "elm/time": "1.0.0",
+      "pzp1997/assoc-list": "1.0.0"
     },
     "indirect": {
       "elm/url": "1.0.0",
@@ -20,8 +22,7 @@
       "elm-explorations/test": "2.2.0"
     },
     "indirect": {
-      "elm/bytes": "1.0.8",
-      "elm/random": "1.0.0"
+      "elm/bytes": "1.0.8"
     }
   }
 }

--- a/source/Main.elm
+++ b/source/Main.elm
@@ -1,32 +1,32 @@
 module Main exposing (main)
 
 import Browser exposing (element)
-import Html exposing (..)
+import Html exposing (text)
 import State exposing (State)
+import State.Delta exposing (Delta, gradient)
 import Time
-import Update exposing (Msg(..))
+import Update exposing (Msg(..), update)
 
 
-main : Program () State Msg
+main : Program () ( Delta, State ) Msg
 main =
     element
         { init =
             \_ ->
-                ( State.initial
+                ( ( gradient State.initial
+                  , State.initial
+                  )
                 , Cmd.none
                 )
         , view =
-            \state ->
+            \( _, state ) ->
                 let
                     money =
                         String.fromFloat state.money
                 in
                 text ("You have $" ++ money ++ ".")
         , update =
-            \_ model ->
-                ( model
-                , Cmd.none
-                )
+            update
         , subscriptions =
             \_ ->
                 Time.every 1000 <|

--- a/source/Update.elm
+++ b/source/Update.elm
@@ -1,19 +1,50 @@
 module Update exposing (Msg(..), update)
 
+import AssocList as Dict exposing (Dict)
+import Random exposing (Generator)
 import State exposing (State)
 import State.Delta exposing (Delta, gradient, step)
 
 
 type Msg
-    = AdvanceGameClock
+    = NoOp
+    | AdvanceGameClock
+    | Probabilities (Dict Msg Float)
 
 
 update : Msg -> ( Delta, State ) -> ( ( Delta, State ), Cmd Msg )
-update msg ( _, model ) =
+update msg ( delta, model ) =
     case msg of
+        NoOp ->
+            ( ( delta, model ), Cmd.none )
+
         AdvanceGameClock ->
             let
                 patch =
                     gradient model
             in
             ( ( patch, step patch model ), Cmd.none )
+
+        Probabilities entries ->
+            let
+                generateEntry : ( Msg, Float ) -> Cmd (Maybe Msg)
+                generateEntry ( key, threshold ) =
+                    Random.float 0 1
+                        |> Random.generate
+                            (\roll ->
+                                if roll < threshold then
+                                    Just key
+
+                                else
+                                    Nothing
+                            )
+
+                results : Cmd Msg
+                results =
+                    entries
+                        |> Dict.toList
+                        |> List.map generateEntry
+                        |> Cmd.batch
+                        |> Cmd.map (Maybe.withDefault NoOp)
+            in
+            ( ( delta, model ), results )


### PR DESCRIPTION
TIL that Elm projects invariably end up with a `NoOp` message to deal with the absence of filtering on commands. In any case, we now have a command for checking probabilistic events.