### PR TITLE
Focus `update` on game events

### DIFF
--- a/source/Main.elm
+++ b/source/Main.elm
@@ -4,9 +4,14 @@ import Browser exposing (element)
 import Html exposing (button, div, p, text)
 import Html.Events exposing (onClick)
 import State exposing (State)
-import State.Delta exposing (Delta, gradient)
+import State.Delta exposing (Delta, gradient, step)
 import Time
-import Update exposing (Event(..), Msg(..), update)
+import Update exposing (Event(..), update)
+
+
+type Msg
+    = AdvanceGameClock
+    | GameEvent Event
 
 
 main : Program () ( Delta, State ) Msg
@@ -39,10 +44,22 @@ main =
                     , p [] [ text ("You have $" ++ money ++ ".") ]
                     ]
         , update =
-            update
+            \msg ( delta, state ) ->
+                case msg of
+                    AdvanceGameClock ->
+                        let
+                            patch =
+                                gradient state
+                        in
+                        ( ( patch, step patch state ), Cmd.none )
+
+                    GameEvent event ->
+                        let
+                            ( updated, cmd ) =
+                                update event state
+                        in
+                        ( ( delta, updated ), Cmd.map GameEvent cmd )
         , subscriptions =
             \_ ->
-                Time.every 1000 <|
-                    \_ ->
-                        Update.AdvanceGameClock
+                Time.every 1000 (always AdvanceGameClock)
         }


### PR DESCRIPTION
As far as updates are concerned, deltas are irrelevant for everything but advancing the world clock, when we generate and store a new one. So, this PR makes the distinction between a `GameEvent` and `AdvanceGameClock`, and `update` only focuses on the first of the two.