### PR TITLE
Minify the `main.js` build

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-build-elm: create-build-directory
+build-elm: create-build-directory install-dependencies
   elm make source/Main.elm --optimize --output=build/main.js
   npx uglifyjs build/main.js \
     --compress 'pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe' \

--- a/justfile
+++ b/justfile
@@ -1,5 +1,9 @@
 build-elm: create-build-directory
   elm make source/Main.elm --optimize --output=build/main.js
+  npx uglifyjs build/main.js \
+    --compress 'pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe' \
+    | npx uglifyjs --mangle --output build/main.min.js
+
 
 build-website: build-elm copy-static-assets
 alias build := build-website

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
         "elm-live": "^4.0.2",
         "elm-test": "^0.19.1-revision12",
         "prettier": "^3.3.3",
-        "prettier-plugin-elm": "^0.11.0"
+        "prettier-plugin-elm": "^0.11.0",
+        "uglify-js": "^3.19.2"
       }
     },
     "node_modules/@avh4/elm-format-darwin-arm64": {
@@ -1554,6 +1555,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.2",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.2.tgz",
+      "integrity": "sha512-S8KA6DDI47nQXJSi2ctQ629YzwOVs+bQML6DAtvy0wgNdpi+0ySpQK0g2pxBq2xfF2z3YCscu7NNA8nXT9PlIQ==",
+      "dev": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "elm-live": "^4.0.2",
     "elm-test": "^0.19.1-revision12",
     "prettier": "^3.3.3",
-    "prettier-plugin-elm": "^0.11.0"
+    "prettier-plugin-elm": "^0.11.0",
+    "uglify-js": "^3.19.2"
   },
   "prettier": {
     "plugins": [

--- a/static/index.html
+++ b/static/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>Initial</title>
-    <script src="main.js"></script>
+    <script src="main.min.js"></script>
   </head>
   <body>
     <div id="application"></div>


### PR DESCRIPTION
This was in the Elm guidebook. It seems to make the bundle 6x smaller at the moment, so it probably can't hurt.