### PR TITLE
Fix the `just dev` command

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,8 +1,8 @@
 build-elm: create-build-directory install-dependencies
-  elm make source/Main.elm --optimize --output=build/main.js
-  npx uglifyjs build/main.js \
+  elm make source/Main.elm --optimize --output=build/main.unminified.js
+  npx uglifyjs build/main.unminified.js \
     --compress 'pure_funcs=[F2,F3,F4,F5,F6,F7,F8,F9,A2,A3,A4,A5,A6,A7,A8,A9],pure_getters,keep_fargs=false,unsafe_comps,unsafe' \
-    | npx uglifyjs --mangle --output build/main.min.js
+    | npx uglifyjs --mangle --output build/main.js
 
 
 build-website: build-elm copy-static-assets


### PR DESCRIPTION
`just dev` doesn't minify, so there's no updated `main.min.js` to include in the `index.html` file. We can solve this with minimal effort by making the minified file's name `main.js`, and the unminified one `main.unminified.js`. That way, both processes output a `main.js`.